### PR TITLE
fix a bug. 

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -9,6 +9,6 @@ output "unique_id" {
 }
 
 output "name" {
-  description = "The IAM Role Name"
-  value       = "${aws_iam_role.this.name}"
+  description = "The Instance profile Name"
+  value       = "${aws_iam_instance_profile.this.name}"
 }


### PR DESCRIPTION
The return value of Key "name" is "aws_iam_role" To "aws_instance_profile".